### PR TITLE
Creating a public NYU mLab GitHub Org README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# .github
-Public README for the NYU mLab GitHub organization
+# NYU mLab public README
+This repository is to have a public README describing the NYU mLab GitHub organization.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,34 @@
+<h1 align="center">Measurement Lab (mLab) </h1>
+The Measurement/Momo Lab is focused on research on IoT devices.
+
+## Members
+[Supreme Director - Momo](https://mlab.engineering.nyu.edu/images/team/momo.jpg)
+
+[Danny Huang - PI](https://engineering.nyu.edu/faculty/danny-yuxing-huang)
+
+[Brandon Sloane (part-time @ CSE)](https://www.linkedin.com/in/bsloane/)
+
+[Grace McGrath (ECE)](https://www.linkedin.com/in/grace-mcgrath/)
+
+[Mo Satt (part-time @ CSE)](https://www.linkedin.com/in/mosatt/)
+
+[Rameen Mahmood (ECE)](https://rameen-mahmood.github.io/)
+
+[Vijay Prakash (ECE)](https://www.linkedin.com/in/viz-prakash/)
+
+[Andrew Quijano (CSE)](https://andrewquijano.github.io/)
+
+## Current Projects
+[Routersense](https://routersense.cyber.nyu.edu/)
+
+[IoT Inspector](https://inspector.engineering.nyu.edu/)
+
+## Past Projects
+
+## Publications
+See the full list of publications [here](https://mlab.engineering.nyu.edu/).
+
+## Sponsors
+
+## Contact
+Reach out to Professor [Danny Huang](dhuang@nyu.edu) via e-mail


### PR DESCRIPTION
I figure we can leverage the fact that the GitHub org can host a README. I started some work for it and possible subsections.

I think this lab has a great template

https://github.com/adwise-fiu/